### PR TITLE
Change pop-up text for new subscription

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -374,7 +374,7 @@ export default new Vuex.Store({
             commit("addSubr", issnl)
             dispatch("updateSummary")
             await dispatch("updateTabData")
-            commit("snackbar", "Article subscribed!")
+            commit("snackbar", "Subscribed to the item!")
             return true
         },
         async removeSubr({commit, dispatch}, issnl) {


### PR DESCRIPTION
When clicking a cart button in the "journals list", it feels confusing
to read "article subscribed". Use "item" instead.